### PR TITLE
Lower producer alert limits

### DIFF
--- a/charts/substrate-telemetry/Chart.yaml
+++ b/charts/substrate-telemetry/Chart.yaml
@@ -1,3 +1,3 @@
 description: Substrate Telemetry Chart
 name: substrate-telemetry
-version: v0.9.7
+version: v0.9.8

--- a/charts/substrate-telemetry/templates/alertrules-validators.yaml
+++ b/charts/substrate-telemetry/templates/alertrules-validators.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: ValidatorPrevotingStallShort
       annotations:
-        message: 'Prevotes were not received for 3 minute from {{`{{ $labels.voter }}`}}'
+        message: 'Prevotes were not received for 3 minutes from {{`{{ $labels.voter }}`}}'
       expr: increase(polkadot_validator_prevote_received_total[3m]) == 0
       for: 1m
       labels:
@@ -25,7 +25,7 @@ spec:
         severity: critical
     - alert: ValidatorPrecommitingStallShort
       annotations:
-        message: 'Precommits were not received for 3 minute from {{`{{ $labels.voter }}`}}'
+        message: 'Precommits were not received for 3 minutes from {{`{{ $labels.voter }}`}}'
       expr: increase(polkadot_validator_precommit_received_total[3m]) == 0
       for: 1m
       labels:
@@ -39,15 +39,15 @@ spec:
         severity: critical
     - alert: ProducerStallShort
       annotations:
-        message: 'Blocks were not produced for 35 minutes by {{`{{ $labels.producer }}`}}'
-      expr: increase(polkadot_block_produced_total[25m]) == 0
+        message: 'Blocks were not produced for 20 minutes by {{`{{ $labels.producer }}`}}'
+      expr: increase(polkadot_block_produced_total[10m]) == 0
       for: 10m
       labels:
         severity: warning
     - alert: ProducerStallLong
       annotations:
-        message: 'Blocks were not produced for 40 minutes by {{`{{ $labels.producer }}`}}'
-      expr: increase(polkadot_block_produced_total[30m]) == 0
+        message: 'Blocks were not produced for 30 minutes by {{`{{ $labels.producer }}`}}'
+      expr: increase(polkadot_block_produced_total[20m]) == 0
       for: 10m
       labels:
         severity: critical

--- a/charts/substrate-telemetry/values.yaml
+++ b/charts/substrate-telemetry/values.yaml
@@ -17,7 +17,7 @@ exporter:
   port: 3000
   image:
     repo: web3f/substrate-telemetry-exporter
-    tag: v0.7.0
+    tag: v0.8.0
   config:
     subscribe:
       chains:


### PR DESCRIPTION
After checking the logs the issue we had with the uneven distribution of block producers seems to have been fixed, these changes lower the range limits for producer alerts again.