### PR TITLE
make resource names depend on release

### DIFF
--- a/charts/substrate-telemetry/Chart.yaml
+++ b/charts/substrate-telemetry/Chart.yaml
@@ -1,3 +1,3 @@
 description: Substrate Telemetry Chart
 name: substrate-telemetry
-version: v1.0.0
+version: v1.0.1

--- a/charts/substrate-telemetry/templates/_helpers.tpl
+++ b/charts/substrate-telemetry/templates/_helpers.tpl
@@ -10,30 +10,30 @@ telemetry.{{ .Values.domain }}
 
 {{/* Returns the TLS secret name to be used in certs and ingress */}}
 {{- define "substrate-telemetry.tlsSecretName" -}}
-substrate-telemetry-tls
+{{ .Release.Name }}-tls
 {{- end }}
 
 {{/* Returns the frontend service name */}}
 {{- define "substrate-telemetry.frontendSvcName" -}}
-substrate-telemetry-frontend
+{{ .Release.Name }}-frontend
 {{- end }}
 
 {{/* Returns the backend service name */}}
 {{- define "substrate-telemetry.backendSvcName" -}}
-substrate-telemetry-backend
+{{ .Release.Name }}-backend
 {{- end }}
 
 {{/* Returns the frontend app name */}}
 {{- define "substrate-telemetry.frontendAppName" -}}
-substrate-telemetry-frontend
+{{ .Release.Name }}-frontend
 {{- end }}
 
 {{/* Returns the backend app name */}}
 {{- define "substrate-telemetry.backendAppName" -}}
-substrate-telemetry-backend
+{{ .Release.Name }}-backend
 {{- end }}
 
 {{/* Returns the generic exporter name */}}
 {{- define "substrate-telemetry.exporterName" -}}
-substrate-telemetry-exporter
+{{ .Release.Name }}-exporter
 {{- end }}

--- a/charts/substrate-telemetry/templates/alertrules-general.yaml
+++ b/charts/substrate-telemetry/templates/alertrules-general.yaml
@@ -4,7 +4,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: polkadot
-  name: polkadot
+  name: {{ .Release.Name }}-polkadot
 spec:
   groups:
   - name: polkadot.rules

--- a/charts/substrate-telemetry/templates/alertrules-validators.yaml
+++ b/charts/substrate-telemetry/templates/alertrules-validators.yaml
@@ -4,7 +4,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: polkadot
-  name: polkadot-validators
+  name: {{ .Release.Name }}-polkadot-validators
 spec:
   groups:
   - name: polkadot-validators.rules

--- a/charts/substrate-telemetry/templates/certificate.yaml
+++ b/charts/substrate-telemetry/templates/certificate.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: telemetry
+  name: {{ .Release.Name }}
   namespace: {{ .Values.namespace }}
 spec:
   secretName: {{ include "substrate-telemetry.tlsSecretName" . }}

--- a/charts/substrate-telemetry/templates/ingress-backend.yaml
+++ b/charts/substrate-telemetry/templates/ingress-backend.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: substrate-telemetry-backend
+  name: {{ include "substrate-telemetry.backendAppName" . }}
   namespace: {{ .Values.namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"

--- a/charts/substrate-telemetry/templates/ingress-frontend.yaml
+++ b/charts/substrate-telemetry/templates/ingress-frontend.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: substrate-telemetry-frontend
+  name: {{ include "substrate-telemetry.frontendAppName" . }}
   namespace: {{ .Values.namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"


### PR DESCRIPTION
Towards https://github.com/w3f/infrastructure/issues/102

We need these changes to be able to deploy two releases of substrate-telemetry