### PR TITLE
Fix frontend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,9 @@ RUN apt update && \
   cd substrate-telemetry && \
   git checkout  ${SUBSTRATE_TELEMETRY_TAG} && \
   cd frontend && \
-  yarn
+  yarn && \
+  yarn build && \
+  yarn global add serve
 
 EXPOSE 3000
 EXPOSE 8000

--- a/charts/substrate-telemetry/Chart.yaml
+++ b/charts/substrate-telemetry/Chart.yaml
@@ -1,4 +1,4 @@
 description: Substrate Telemetry Chart
 name: substrate-telemetry
-version: v2.4.0
+version: v2.4.1
 apiVersion: v2

--- a/charts/substrate-telemetry/templates/deployment-frontend.yaml
+++ b/charts/substrate-telemetry/templates/deployment-frontend.yaml
@@ -25,7 +25,8 @@ spec:
         command:
         - serve
         args:
-        - s
+        - -l
+        - {{ .Values.frontendPort | quote }}
         - build
         workingDir: /app/substrate-telemetry/frontend
         ports:

--- a/charts/substrate-telemetry/templates/deployment-frontend.yaml
+++ b/charts/substrate-telemetry/templates/deployment-frontend.yaml
@@ -23,9 +23,10 @@ spec:
         image: {{ .Values.image.repo }}:{{ .Values.image.tag }}
         imagePullPolicy: IfNotPresent
         command:
-        - yarn
+        - serve
         args:
-        - start
+        - s
+        - build
         workingDir: /app/substrate-telemetry/frontend
         ports:
         - name: frontend
@@ -40,9 +41,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 800Mi
+            memory: 80Mi
           requests:
             cpu: 100m
-            memory: 800Mi
+            memory: 80Mi
         {{ end }}
 {{- end }}

--- a/charts/substrate-telemetry/templates/deployment-frontend.yaml
+++ b/charts/substrate-telemetry/templates/deployment-frontend.yaml
@@ -42,9 +42,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 80Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 80Mi
+            memory: 200Mi
         {{ end }}
 {{- end }}

--- a/charts/substrate-telemetry/values.yaml
+++ b/charts/substrate-telemetry/values.yaml
@@ -1,6 +1,6 @@
 image:
   repo: web3f/substrate-telemetry
-  tag: v2.4.0
+  tag: v2.4.1
 
 environment: production
 


### PR DESCRIPTION
We were previously building and serving a development version of substrate-telemetry frontend. The build process required a lot of resources and time. With these changes we build the project while building the image, and in production we just run a simple app to serve the prebuilt static files, with a much lower resource footprint and an almost instant boot.